### PR TITLE
added traceexecute event callback

### DIFF
--- a/swig/x64dbgpy/__events.py
+++ b/swig/x64dbgpy/__events.py
@@ -15,6 +15,7 @@ EVENTS = [
     'system_breakpoint',
     'load_dll',
     'unload_dll',
+    'trace_execute'
 ]
 
 class Event(object):
@@ -88,6 +89,13 @@ class Event(object):
         #     UNLOAD_DLL_DEBUG_INFO* UnloadDll;
         # } PLUG_CB_UNLOADDLL;
         self.unload_dll = None
+        # Keys: trace
+        # typedef struct
+        # {
+        #     duint cip;
+        #     bool stop;
+        # } PLUG_CB_TRACEEXECUTE;
+        self.trace_execute = None
 
     def listen(self, event_name, callback):
         """


### PR DESCRIPTION
Hi,
i've read the hint
> Translating the event callbacks to swig and use it without the code in py.cpp file.

in the readme but sorry, i have no idea how since im not so familiar with c++. But i wanted to try the traceexecute plugin callback and added it in py.cpp because this was easy enough for me and of course i wanted to share it.