### PR TITLE
Hack/workaround to ignore Win10 write exception

### DIFF
--- a/swig/x64dbgpy/hooks.py
+++ b/swig/x64dbgpy/hooks.py
@@ -52,8 +52,7 @@ class OutputHook(object):
         try:
             self.__original_stream.write(text)
         except IOError as e:
-            if e.errno != 0:
-                raise e
+            pass
 
     def start(self):
         if not self.is_hooking:

--- a/swig/x64dbgpy/hooks.py
+++ b/swig/x64dbgpy/hooks.py
@@ -41,7 +41,19 @@ class OutputHook(object):
 
     def write(self, text):
         self.callback(text)
-        self.__original_stream.write(text)
+
+        # Hack to workaround a Windows 10 version < 1803 specific error.
+        # IOError errno=0 occurs when writing to stderr or stdout after an exception occurs.
+        # Issue: https://github.com/x64dbg/x64dbgpy/issues/31
+        # See:
+        #    https://bugs.python.org/issue32245
+        #    https://github.com/Microsoft/console/issues/40
+        #    https://github.com/Microsoft/vscode/issues/36630
+        try:
+            self.__original_stream.write(text)
+        except IOError as e:
+            if e.errno != 0:
+                raise e
 
     def start(self):
         if not self.is_hooking:

--- a/swig/x64dbgpy/hooks.py
+++ b/swig/x64dbgpy/hooks.py
@@ -42,13 +42,15 @@ class OutputHook(object):
     def write(self, text):
         self.callback(text)
 
-        # Hack to workaround a Windows 10 version < 1803 specific error.
-        # IOError errno=0 occurs when writing to stderr or stdout after an exception occurs.
+        # Hack to workaround a Windows 10 specific error.
+        # IOError (errno=0 OR errno=9) occurs when writing to stderr or stdout after an exception occurs.
         # Issue: https://github.com/x64dbg/x64dbgpy/issues/31
         # See:
         #    https://bugs.python.org/issue32245
         #    https://github.com/Microsoft/console/issues/40
         #    https://github.com/Microsoft/vscode/issues/36630
+        # Further issue discussion:
+        #    https://github.com/x64dbg/x64dbgpy/pull/32
         try:
             self.__original_stream.write(text)
         except IOError as e:


### PR DESCRIPTION
This is a quick hack/workaround for #31 which probably shouldn't be merged (simply ignores the exception). The _proper_ solution would be to update to Win10 >= 1803.

`WriteFile` was bugged in some windows 10 versions before 1803 (see https://github.com/Microsoft/console/issues/40) and returned a incorrect length value, causing python's `write()` to fail (see https://bugs.python.org/issue32245).