### PR TITLE
[PyAPI]: Fixed imports (ctypes)

### DIFF
--- a/swig/x64dbgpy/pluginsdk/_scriptapi/gui.py
+++ b/swig/x64dbgpy/pluginsdk/_scriptapi/gui.py
@@ -1,3 +1,4 @@
+import ctypes
 from .. import x64dbg
 
 


### PR DESCRIPTION
Added missing import 'ctypes' in gui.py